### PR TITLE
Fix for duplicate config on reinit

### DIFF
--- a/util/proc.go
+++ b/util/proc.go
@@ -29,5 +29,5 @@ func GitConfig(name string) string {
 }
 
 func SetGitConfig(name string, value string) {
-    Stdout("git", "config", "--add", name, value)
+    Stdout("git", "config", "--replace-all", name, value)
 }


### PR DESCRIPTION
I noticed that rerunning `git fit init` would cause the AWS keys to get duplicated in the configuration file. This fix should prevent that from happening by replacing them instead of adding a duplicate key. In the case of the first `init`, `--replace-all` will create a new key if it isn't present.

Tested under git v2.2.2.