### PR TITLE
Feature/update gc command to check sha1sum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /git-fit
 /integration
+
+.vscode*

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ deps:
 	go get -u github.com/mitchellh/goamz/aws
 	go get -u github.com/mitchellh/goamz/s3
 	go get -u github.com/cheggaaa/pb
-	go get -u github.com/github.com/smartystreets/goconvey/convey
+	go get -u github.com/smartystreets/goconvey/convey
 
 unittests:
 	go test github.com/dailymuse/git-fit/transport github.com/dailymuse/git-fit/util

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ deps:
 	go get -u github.com/mitchellh/goamz/aws
 	go get -u github.com/mitchellh/goamz/s3
 	go get -u github.com/cheggaaa/pb
+	go get -u github.com/github.com/smartystreets/goconvey/convey
 
 unittests:
 	go test github.com/dailymuse/git-fit/transport github.com/dailymuse/git-fit/util

--- a/cli/gc.go
+++ b/cli/gc.go
@@ -13,33 +13,33 @@ import (
 const gitFitCacheDir = ".git/fit"
 
 func Gc(schema *config.Config, trans transport.Transport, args []string) {
-	filesDeclaredInSchema := make(map[string]bool, len(schema.Files)*2)
+	fileHashesDeclaredInSchema := make(map[string]bool, len(schema.Files)*2)
 
 	for _, hash := range schema.Files {
-		filesDeclaredInSchema[hash] = true
+		fileHashesDeclaredInSchema[hash] = true
 	}
 
-	allFiles, err := ioutil.ReadDir(gitFitCacheDir)
+	cacheFiles, err := ioutil.ReadDir(gitFitCacheDir)
 
 	if err != nil {
 		util.Fatal("Could not read %s: %s\n", gitFitCacheDir, err.Error())
 	}
 
-	for _, file := range allFiles {
-		fileNameHash := file.Name()
+	for _, cacheFile := range cacheFiles {
+		cacheFileName := cacheFile.Name()
 
 		if err := util.SHA1sumIsValidForCacheFile(util.SHA1sumValidatorArgs{
 			ReadDir:                 gitFitCacheDir,
-			FileName:                fileNameHash,
+			FileName:                cacheFileName,
 			GenerateSHA1Sum:         util.FileHash,
-			CacheFileHashesInSchema: filesDeclaredInSchema,
+			CacheFileHashesInSchema: fileHashesDeclaredInSchema,
 		}); err != nil {
 			util.Error("%s", err.Error())
-			path := fmt.Sprintf("%s/%s", gitFitCacheDir, file.Name())
+			path := fmt.Sprintf("%s/%s", gitFitCacheDir, cacheFile.Name())
 			err = os.Remove(path)
 
 			if err != nil {
-				util.Error("Could not delete cached file %s: %s\n", path, err.Error())
+				util.Error("Could not delete cach file %s: %s\n", path, err.Error())
 			}
 		}
 	}

--- a/cli/gc.go
+++ b/cli/gc.go
@@ -2,31 +2,40 @@ package cli
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/dailymuse/git-fit/config"
 	"github.com/dailymuse/git-fit/transport"
 	"github.com/dailymuse/git-fit/util"
-	"io/ioutil"
-	"os"
 )
 
+const gitFitCacheDir = ".git/fit"
+
 func Gc(schema *config.Config, trans transport.Transport, args []string) {
-	savedFiles := make(map[string]bool, len(schema.Files)*2)
+	filesDeclaredInSchema := make(map[string]bool, len(schema.Files)*2)
 
 	for _, hash := range schema.Files {
-		savedFiles[hash] = true
+		filesDeclaredInSchema[hash] = true
 	}
 
-	allFiles, err := ioutil.ReadDir(".git/fit")
+	allFiles, err := ioutil.ReadDir(gitFitCacheDir)
 
 	if err != nil {
-		util.Fatal("Could not read .git/fit: %s\n", err.Error())
+		util.Fatal("Could not read %s: %s\n", gitFitCacheDir, err.Error())
 	}
 
 	for _, file := range allFiles {
-		_, ok := savedFiles[file.Name()]
+		fileNameHash := file.Name()
 
-		if !ok {
-			path := fmt.Sprintf(".git/fit/%s", file.Name())
+		if err := sha1sumIsValidForCacheFile(sha1sumValidatorArgs{
+			readDir:                 gitFitCacheDir,
+			fileName:                fileNameHash,
+			generateSHA1Sum:         util.FileHash,
+			cacheFileHashesInSchema: filesDeclaredInSchema,
+		}); err != nil {
+			util.Error("%s", err.Error())
+			path := fmt.Sprintf("%s/%s", gitFitCacheDir, file.Name())
 			err = os.Remove(path)
 
 			if err != nil {
@@ -34,4 +43,48 @@ func Gc(schema *config.Config, trans transport.Transport, args []string) {
 			}
 		}
 	}
+}
+
+type sha1sumValidatorArgs struct {
+	fileName                string
+	readDir                 string
+	cacheFileHashesInSchema map[string]bool
+	generateSHA1Sum         sha1SumGenerator
+}
+
+// fileReader is reponsible for opening files on FS.
+type fileReader func(filename string) ([]byte, error)
+
+// sha1SumGenerator is responsible for generating a sha1sum from a byte array.
+type sha1SumGenerator func(p string) (string, error)
+
+func sha1sumIsValidForCacheFile(args sha1sumValidatorArgs) error {
+	// Check to see if the file name SHA we're validating exists in the schema.
+	_, cacheObjExistsInSchema := args.cacheFileHashesInSchema[args.fileName]
+	if !cacheObjExistsInSchema {
+		return fmt.Errorf(
+			"file hash '%s' does not exist in schema",
+			args.fileName,
+		)
+	}
+
+	// Attempt to generate the SHA1Sum for the cache file.
+	filePath := fmt.Sprintf("%s/%s", args.readDir, args.fileName)
+	fileSHA1Sum, err := args.generateSHA1Sum(filePath)
+	if err != nil {
+		return fmt.Errorf(
+			"could not generate file hash: %s",
+			err.Error(),
+		)
+	}
+
+	// Check to make the correlating schema's hash equals the sha1sum of the cache file.
+	if fileSHA1Sum != args.fileName {
+		return fmt.Errorf(
+			"cache file '%s' did not equal the sha1sum of the correlating cache blob",
+			args.fileName,
+		)
+	}
+
+	return nil
 }

--- a/cli/gc.go
+++ b/cli/gc.go
@@ -9,7 +9,7 @@ import (
 const gitFitCacheDir = ".git/fit"
 
 // Gc is responsible for removing invalid cache objects not declared in the git-fit schema.json.
-func Gc(args GCArgs) error {
+func Gc(args GcArgs) error {
 	fileHashesDeclaredInSchema := make(map[string]bool, len(args.Schema.Files)*2)
 
 	for _, hash := range args.Schema.Files {

--- a/cli/gc.go
+++ b/cli/gc.go
@@ -35,7 +35,7 @@ func Gc(schema *config.Config, trans transport.Transport, args []string) {
 			CacheFileHashesInSchema: fileHashesDeclaredInSchema,
 		}); err != nil {
 			util.Error("%s", err.Error())
-			path := fmt.Sprintf("%s/%s", gitFitCacheDir, cacheFile.Name())
+			path := fmt.Sprintf("%s/%s \n", gitFitCacheDir, cacheFile.Name())
 			err = os.Remove(path)
 
 			if err != nil {

--- a/cli/gc_test.go
+++ b/cli/gc_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dailymuse/git-fit/config"
+	"github.com/dailymuse/git-fit/util"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -19,7 +20,7 @@ func TestValidateCacheFile(t *testing.T) {
 				},
 			}
 
-			err := Gc(GCArgs{
+			err := Gc(GcArgs{
 				Args:   []string{"1"},
 				Schema: &config,
 				ReadDir: func(dirname string) ([]os.FileInfo, error) {
@@ -40,10 +41,10 @@ func TestValidateCacheFile(t *testing.T) {
 				},
 			}
 
-			file := NewMockFileInfo("not-a-real-sha-this-should-not-exist-in-schema")
+			file := util.NewMockFileInfo("not-a-real-sha-this-should-not-exist-in-schema")
 			files := []os.FileInfo{file}
 
-			err := Gc(GCArgs{
+			err := Gc(GcArgs{
 				Args:   []string{"1"},
 				Schema: &config,
 				ReadDir: func(dirname string) ([]os.FileInfo, error) {
@@ -71,10 +72,10 @@ func TestValidateCacheFile(t *testing.T) {
 					},
 				}
 
-				file := NewMockFileInfo("69e542360fa6f81b704199685432ddea1dc60944")
+				file := util.NewMockFileInfo("69e542360fa6f81b704199685432ddea1dc60944")
 				files := []os.FileInfo{file}
 
-				err := Gc(GCArgs{
+				err := Gc(GcArgs{
 					Args:   []string{"1"},
 					Schema: &config,
 					ReadDir: func(dirname string) ([]os.FileInfo, error) {
@@ -105,10 +106,10 @@ func TestValidateCacheFile(t *testing.T) {
 					},
 				}
 
-				file := NewMockFileInfo("69e542360fa6f81b704199685432ddea1dc60944")
+				file := util.NewMockFileInfo("69e542360fa6f81b704199685432ddea1dc60944")
 				files := []os.FileInfo{file}
 
-				err := Gc(GCArgs{
+				err := Gc(GcArgs{
 					Args:   []string{"1"},
 					Schema: &config,
 					ReadDir: func(dirname string) ([]os.FileInfo, error) {

--- a/cli/gc_test.go
+++ b/cli/gc_test.go
@@ -63,7 +63,7 @@ func TestValidateCacheFile(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
-		Convey("if the sha1sum of a cached file does not match the sha1sum correlating to the schema, it should delete the cache", func() {
+		Convey("if the SHA1Sum of a cached file does not match the SHA1Sum correlating to the schema, it should delete the cache", func() {
 			Convey("if it fails to delete the cache file, it should return an error", func() {
 				config := config.Config{
 					Version: 1,

--- a/cli/gc_test.go
+++ b/cli/gc_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/dailymuse/git-fit/config"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestValidateCacheFile(t *testing.T) {
+	Convey("Given a file configuration", t, func() {
+		Convey("if reading the cache directory fails, it should return an error", func() {
+			config := config.Config{
+				Version: 1,
+				Files: map[string]string{
+					"etc/pg.dump.tar.gz": "69e542360fa6f81b704199685432ddea1dc60944",
+				},
+			}
+
+			err := Gc(GCArgs{
+				Args:   []string{"1"},
+				Schema: &config,
+				ReadDir: func(dirname string) ([]os.FileInfo, error) {
+					So(dirname, ShouldEqual, ".git/fit")
+					return nil, errors.New("could not read cache dir")
+				},
+				LogError: func(format string, args ...interface{}) {},
+			})
+
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("if the cache file sha does not exist in the schema, remove the cache and return nil", func() {
+			config := config.Config{
+				Version: 1,
+				Files: map[string]string{
+					"etc/pg.dump.tar.gz": "69e542360fa6f81b704199685432ddea1dc60944",
+				},
+			}
+
+			file := NewMockFileInfo("not-a-real-sha-this-should-not-exist-in-schema")
+			files := []os.FileInfo{file}
+
+			err := Gc(GCArgs{
+				Args:   []string{"1"},
+				Schema: &config,
+				ReadDir: func(dirname string) ([]os.FileInfo, error) {
+					So(dirname, ShouldEqual, ".git/fit")
+					return files, nil
+				},
+				LogError: func(format string, args ...interface{}) {
+					return
+				},
+				RemoveFile: func(filePath string) error {
+					So(filePath, ShouldEqual, ".git/fit/not-a-real-sha-this-should-not-exist-in-schema")
+					return nil
+				},
+			})
+
+			So(err, ShouldBeNil)
+		})
+
+		Convey("if the sha1sum of a cached file does not match the sha1sum correlating to the schema, it should delete the cache", func() {
+			Convey("if it fails to delete the cache file, it should return an error", func() {
+				config := config.Config{
+					Version: 1,
+					Files: map[string]string{
+						"etc/pg.dump.tar.gz": "69e542360fa6f81b704199685432ddea1dc60944",
+					},
+				}
+
+				file := NewMockFileInfo("69e542360fa6f81b704199685432ddea1dc60944")
+				files := []os.FileInfo{file}
+
+				err := Gc(GCArgs{
+					Args:   []string{"1"},
+					Schema: &config,
+					ReadDir: func(dirname string) ([]os.FileInfo, error) {
+						So(dirname, ShouldEqual, ".git/fit")
+						return files, nil
+					},
+					LogError: func(format string, args ...interface{}) {
+						return
+					},
+					SHA1SumGenerator: func(p string) (string, error) {
+						So(p, ShouldEqual, ".git/fit/69e542360fa6f81b704199685432ddea1dc60944")
+						return "69e542360fa6f81b704", nil
+					},
+					RemoveFile: func(filePath string) error {
+						So(filePath, ShouldEqual, ".git/fit/69e542360fa6f81b704199685432ddea1dc60944")
+						return errors.New("failed to delete cache file")
+					},
+				})
+
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("if the cache was successfully deleted it should return nil", func() {
+				config := config.Config{
+					Version: 1,
+					Files: map[string]string{
+						"etc/pg.dump.tar.gz": "69e542360fa6f81b704199685432ddea1dc60944",
+					},
+				}
+
+				file := NewMockFileInfo("69e542360fa6f81b704199685432ddea1dc60944")
+				files := []os.FileInfo{file}
+
+				err := Gc(GCArgs{
+					Args:   []string{"1"},
+					Schema: &config,
+					ReadDir: func(dirname string) ([]os.FileInfo, error) {
+						So(dirname, ShouldEqual, ".git/fit")
+						return files, nil
+					},
+					LogError: func(format string, args ...interface{}) {
+						return
+					},
+					SHA1SumGenerator: func(p string) (string, error) {
+						So(p, ShouldEqual, ".git/fit/69e542360fa6f81b704199685432ddea1dc60944")
+						return "69e542360fa6f81b704", nil
+					},
+					RemoveFile: func(filePath string) error {
+						So(filePath, ShouldEqual, ".git/fit/69e542360fa6f81b704199685432ddea1dc60944")
+						return nil
+					},
+				})
+
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/cli/interfaces.go
+++ b/cli/interfaces.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"os"
+	"time"
+
+	"github.com/dailymuse/git-fit/config"
+	"github.com/dailymuse/git-fit/util"
+)
+
+// GCArgs TODO write comment
+type GCArgs struct {
+	Args             []string
+	Schema           *config.Config
+	ReadDir          dirFileReader
+	RemoveFile       fileRemover
+	LogError         errorLogger
+	SHA1SumIsValid   util.SHA1sumValidatorArgs
+	SHA1SumGenerator util.SHA1SumGenerator
+}
+
+type dirFileReader func(dirname string) ([]os.FileInfo, error)
+
+type fileRemover func(name string) error
+
+type errorLogger func(format string, args ...interface{})
+
+// MockFileInfo TODO fillout
+type MockFileInfo struct {
+	name string
+}
+
+// NewMockFileInfo TODO fill out
+func NewMockFileInfo(mockFileName string) os.FileInfo {
+	return MockFileInfo{
+		name: mockFileName,
+	}
+}
+
+func (m MockFileInfo) Name() string {
+	return m.name
+}
+
+func (m MockFileInfo) Size() int64 {
+	return 0
+}
+
+func (m MockFileInfo) Mode() os.FileMode {
+	return os.ModeDir
+}
+
+func (m MockFileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (m MockFileInfo) IsDir() bool {
+	return false
+}
+
+func (m MockFileInfo) Sys() interface{} {
+	return nil
+}

--- a/cli/interfaces.go
+++ b/cli/interfaces.go
@@ -2,14 +2,13 @@ package cli
 
 import (
 	"os"
-	"time"
 
 	"github.com/dailymuse/git-fit/config"
 	"github.com/dailymuse/git-fit/util"
 )
 
-// GCArgs TODO write comment
-type GCArgs struct {
+// GcArgs is the arguments struct for Gc.
+type GcArgs struct {
 	Args             []string
 	Schema           *config.Config
 	ReadDir          dirFileReader
@@ -19,44 +18,12 @@ type GCArgs struct {
 	SHA1SumGenerator util.SHA1SumGenerator
 }
 
+// dirFileReader is responsible for reading a directory and return an array
+// of FileInfo.
 type dirFileReader func(dirname string) ([]os.FileInfo, error)
 
+// fileRemover is responsible for removing a file from the file system.
 type fileRemover func(name string) error
 
+// errorLogger is responsible for logging errors.
 type errorLogger func(format string, args ...interface{})
-
-// MockFileInfo TODO fillout
-type MockFileInfo struct {
-	name string
-}
-
-// NewMockFileInfo TODO fill out
-func NewMockFileInfo(mockFileName string) os.FileInfo {
-	return MockFileInfo{
-		name: mockFileName,
-	}
-}
-
-func (m MockFileInfo) Name() string {
-	return m.name
-}
-
-func (m MockFileInfo) Size() int64 {
-	return 0
-}
-
-func (m MockFileInfo) Mode() os.FileMode {
-	return os.ModeDir
-}
-
-func (m MockFileInfo) ModTime() time.Time {
-	return time.Time{}
-}
-
-func (m MockFileInfo) IsDir() bool {
-	return false
-}
-
-func (m MockFileInfo) Sys() interface{} {
-	return nil
-}

--- a/git-fit.go
+++ b/git-fit.go
@@ -99,7 +99,7 @@ func main() {
 		case "pull":
 			cli.Pull(schema, trans, os.Args[2:])
 		case "gc":
-			if err = cli.Gc(cli.GCArgs{
+			if err = cli.Gc(cli.GcArgs{
 				Args:             os.Args[2:],
 				Schema:           schema,
 				ReadDir:          ioutil.ReadDir,

--- a/git-fit.go
+++ b/git-fit.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/dailymuse/git-fit/cli"
 	"github.com/dailymuse/git-fit/config"
 	"github.com/dailymuse/git-fit/transport"
 	"github.com/dailymuse/git-fit/util"
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/s3"
-	"os"
-	"path/filepath"
 )
 
 func help(code int) {
@@ -97,7 +99,16 @@ func main() {
 		case "pull":
 			cli.Pull(schema, trans, os.Args[2:])
 		case "gc":
-			cli.Gc(schema, trans, os.Args[2:])
+			if err = cli.Gc(cli.GCArgs{
+				Args:             os.Args[2:],
+				Schema:           schema,
+				ReadDir:          ioutil.ReadDir,
+				LogError:         util.Message,
+				RemoveFile:       os.Remove,
+				SHA1SumGenerator: util.FileHash,
+			}); err != nil {
+				util.Fatal(err.Error())
+			}
 		case "status":
 			cli.Status(schema, trans, os.Args[2:])
 		default:

--- a/util/cache_file_hash_validator.go
+++ b/util/cache_file_hash_validator.go
@@ -1,0 +1,36 @@
+package util
+
+import "fmt"
+
+// SHA1sumIsValidForCacheFile verifies the integreity of a given cache file by generating
+// and checking the sha1sum of the cache file compared to the correlating schema's hash.
+func SHA1sumIsValidForCacheFile(args SHA1sumValidatorArgs) error {
+	// Check to see if the file name SHA we're validating exists in the schema.
+	_, cacheObjExistsInSchema := args.CacheFileHashesInSchema[args.FileName]
+	if !cacheObjExistsInSchema {
+		return fmt.Errorf(
+			"file hash '%s' does not exist in schema",
+			args.FileName,
+		)
+	}
+
+	// Attempt to generate the SHA1Sum for the cache file.
+	filePath := fmt.Sprintf("%s/%s", args.ReadDir, args.FileName)
+	fileSHA1Sum, err := args.GenerateSHA1Sum(filePath)
+	if err != nil {
+		return fmt.Errorf(
+			"could not generate file hash: %s",
+			err.Error(),
+		)
+	}
+
+	// Check to make the correlating schema's hash equals the sha1sum of the cache file.
+	if fileSHA1Sum != args.FileName {
+		return fmt.Errorf(
+			"cache file '%s' did not equal the sha1sum of the correlating cache blob",
+			args.FileName,
+		)
+	}
+
+	return nil
+}

--- a/util/cache_file_hash_validator.go
+++ b/util/cache_file_hash_validator.go
@@ -24,7 +24,7 @@ func SHA1sumIsValidForCacheFile(args SHA1sumValidatorArgs) error {
 		)
 	}
 
-	// Check to make the correlating schema's hash equals the SHA1Sum of the cache file.
+	// Verify the correlating schema's hash equals the SHA1Sum of the cache file.
 	if fileSHA1Sum != args.FileName {
 		return fmt.Errorf(
 			"cache file '%s' did not equal the SHA1Sum of the correlating cache blob",

--- a/util/cache_file_hash_validator.go
+++ b/util/cache_file_hash_validator.go
@@ -3,7 +3,7 @@ package util
 import "fmt"
 
 // SHA1sumIsValidForCacheFile verifies the integreity of a given cache file by generating
-// and checking the sha1sum of the cache file compared to the correlating schema's hash.
+// and checking the SHA1Sum of the cache file compared to the correlating schema's hash.
 func SHA1sumIsValidForCacheFile(args SHA1sumValidatorArgs) error {
 	// Check to see if the file name SHA we're validating exists in the schema.
 	_, cacheObjExistsInSchema := args.CacheFileHashesInSchema[args.FileName]
@@ -24,10 +24,10 @@ func SHA1sumIsValidForCacheFile(args SHA1sumValidatorArgs) error {
 		)
 	}
 
-	// Check to make the correlating schema's hash equals the sha1sum of the cache file.
+	// Check to make the correlating schema's hash equals the SHA1Sum of the cache file.
 	if fileSHA1Sum != args.FileName {
 		return fmt.Errorf(
-			"cache file '%s' did not equal the sha1sum of the correlating cache blob",
+			"cache file '%s' did not equal the SHA1Sum of the correlating cache blob",
 			args.FileName,
 		)
 	}

--- a/util/cache_file_hash_validator_test.go
+++ b/util/cache_file_hash_validator_test.go
@@ -21,20 +21,20 @@ func TestValidateCacheFile(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("if the sha1sum generator fails to generate a SHA from cache file, it should return an error", func() {
+		Convey("if the SHA1Sum generator fails to generate a SHA from cache file, it should return an error", func() {
 			err := SHA1sumIsValidForCacheFile(SHA1sumValidatorArgs{
 				ReadDir:  "./git/fit",
 				FileName: "69e542360fa6f81b704199685432ddea1dc60944",
 				GenerateSHA1Sum: func(p string) (string, error) {
 					So(p, ShouldEqual, fmt.Sprintf("./git/fit/69e542360fa6f81b704199685432ddea1dc60944"))
-					return "", errors.New("error generating file sha1sum")
+					return "", errors.New("error generating file SHA1Sum")
 				},
 				CacheFileHashesInSchema: map[string]bool{"69e542360fa6f81b704199685432ddea1dc60944": true},
 			})
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("if the sha1sum of the cache file does not match the correlating schema sha1sum, it should return an error", func() {
+		Convey("if the SHA1Sum of the cache file does not match the correlating schema SHA1Sum, it should return an error", func() {
 			err := SHA1sumIsValidForCacheFile(SHA1sumValidatorArgs{
 				ReadDir:  "./git/fit",
 				FileName: "69e542360fa6f81b704199685432ddea1dc60944",
@@ -47,7 +47,7 @@ func TestValidateCacheFile(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("if the sha1sum of the cache file matches the correlating schema sha1sum, it should return nil", func() {
+		Convey("if the SHA1Sum of the cache file matches the correlating schema SHA1Sum, it should return nil", func() {
 			err := SHA1sumIsValidForCacheFile(SHA1sumValidatorArgs{
 				ReadDir:  "./git/fit",
 				FileName: "69e542360fa6f81b704199685432ddea1dc60944",

--- a/util/cache_file_hash_validator_test.go
+++ b/util/cache_file_hash_validator_test.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestValidateCacheFile(t *testing.T) {
+	Convey("Given a cache file hash", t, func() {
+
+		Convey("if the file hash does not exist in the schema, it should return an error", func() {
+			err := SHA1sumIsValidForCacheFile(SHA1sumValidatorArgs{
+				ReadDir:                 "./git/fit",
+				FileName:                "69e542360fa6f81b704199685432ddea1dc6094",
+				CacheFileHashesInSchema: map[string]bool{},
+			})
+			So(err.Error(), ShouldEqual, "file hash '69e542360fa6f81b704199685432ddea1dc6094' does not exist in schema")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("if the sha1sum generator fails to generate a SHA from cache file, it should return an error", func() {
+			err := SHA1sumIsValidForCacheFile(SHA1sumValidatorArgs{
+				ReadDir:  "./git/fit",
+				FileName: "69e542360fa6f81b704199685432ddea1dc60944",
+				GenerateSHA1Sum: func(p string) (string, error) {
+					So(p, ShouldEqual, fmt.Sprintf("./git/fit/69e542360fa6f81b704199685432ddea1dc60944"))
+					return "", errors.New("error generating file sha1sum")
+				},
+				CacheFileHashesInSchema: map[string]bool{"69e542360fa6f81b704199685432ddea1dc60944": true},
+			})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("if the sha1sum of the cache file does not match the correlating schema sha1sum, it should return an error", func() {
+			err := SHA1sumIsValidForCacheFile(SHA1sumValidatorArgs{
+				ReadDir:  "./git/fit",
+				FileName: "69e542360fa6f81b704199685432ddea1dc60944",
+				GenerateSHA1Sum: func(p string) (string, error) {
+					So(p, ShouldEqual, fmt.Sprintf("./git/fit/69e542360fa6f81b704199685432ddea1dc60944"))
+					return "69e542360fa6", nil
+				},
+				CacheFileHashesInSchema: map[string]bool{"69e542360fa6f81b704199685432ddea1dc60944": true},
+			})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("if the sha1sum of the cache file matches the correlating schema sha1sum, it should return nil", func() {
+			err := SHA1sumIsValidForCacheFile(SHA1sumValidatorArgs{
+				ReadDir:  "./git/fit",
+				FileName: "69e542360fa6f81b704199685432ddea1dc60944",
+				GenerateSHA1Sum: func(p string) (string, error) {
+					So(p, ShouldEqual, fmt.Sprintf("./git/fit/69e542360fa6f81b704199685432ddea1dc60944"))
+					return "69e542360fa6f81b704199685432ddea1dc60944", nil
+				},
+				CacheFileHashesInSchema: map[string]bool{"69e542360fa6f81b704199685432ddea1dc60944": true},
+			})
+			So(err, ShouldBeNil)
+		})
+	})
+}

--- a/util/interfaces.go
+++ b/util/interfaces.go
@@ -9,5 +9,5 @@ type SHA1sumValidatorArgs struct {
 	GenerateSHA1Sum         SHA1SumGenerator
 }
 
-// SHA1SumGenerator is responsible for generating a sha1sum from a byte array.
+// SHA1SumGenerator is responsible for generating a SHA1Sum from a byte array.
 type SHA1SumGenerator func(p string) (string, error)

--- a/util/interfaces.go
+++ b/util/interfaces.go
@@ -1,0 +1,13 @@
+package util
+
+// SHA1sumValidatorArgs is the arguments struct for SHA1sumIsValidForCacheFile and
+// SHA1sumIsValidForCacheFile.
+type SHA1sumValidatorArgs struct {
+	FileName                string
+	ReadDir                 string
+	CacheFileHashesInSchema map[string]bool
+	GenerateSHA1Sum         sha1SumGenerator
+}
+
+// sha1SumGenerator is responsible for generating a sha1sum from a byte array.
+type sha1SumGenerator func(p string) (string, error)

--- a/util/interfaces.go
+++ b/util/interfaces.go
@@ -6,8 +6,8 @@ type SHA1sumValidatorArgs struct {
 	FileName                string
 	ReadDir                 string
 	CacheFileHashesInSchema map[string]bool
-	GenerateSHA1Sum         sha1SumGenerator
+	GenerateSHA1Sum         SHA1SumGenerator
 }
 
-// sha1SumGenerator is responsible for generating a sha1sum from a byte array.
-type sha1SumGenerator func(p string) (string, error)
+// SHA1SumGenerator is responsible for generating a sha1sum from a byte array.
+type SHA1SumGenerator func(p string) (string, error)

--- a/util/mock_file_info.go
+++ b/util/mock_file_info.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"os"
+	"time"
+)
+
+// MockFileInfo mocks the os.FileInfo interface.
+type MockFileInfo struct {
+	name string
+}
+
+// NewMockFileInfo returns a new instance of MockFileInfo.
+func NewMockFileInfo(mockFileName string) os.FileInfo {
+	return MockFileInfo{
+		name: mockFileName,
+	}
+}
+
+// Name returns the mock file name.
+func (m MockFileInfo) Name() string {
+	return m.name
+}
+
+// Size returns a zero value for size.
+func (m MockFileInfo) Size() int64 {
+	return 0
+}
+
+// Mode returns an empty os.ModeDir for the file's mode bits.
+func (m MockFileInfo) Mode() os.FileMode {
+	return os.ModeDir
+}
+
+// ModTime returns an empty time.Time for the last modification time.
+func (m MockFileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+// IsDir returns a zero value for if fileInfo is a directory.
+func (m MockFileInfo) IsDir() bool {
+	return false
+}
+
+// Sys returns nil for the underlying file data source.
+func (m MockFileInfo) Sys() interface{} {
+	return nil
+}


### PR DESCRIPTION
### -Bug Overview-
I ran into a pretty weird bug with git-fit when trying to clear cache and pull down an asset. I had an asset I that was corrupt, and could not be untarred, it kept saying the following:

```sh
(venv) vagrant@www:/vagrant$ tar -vxzf etc/pg.dump.tar.gz
etc/pg.dump

gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
```

I tried to clear the cache and re-pull the asset, but still nothing changed. After much frustration I realized the asset gif-fit downloaded was corrupted, and had about a 12MB diff of data loss. The cache located in `.git/fit/...` was also corrupted and git-fit refused to clear it. Once I deleted the cache file manually, I was able to re-download the resource.

### -Change Overview-

Git-fit's `Gc` command does not check cache files for data integrity as criteria for removing invalid cache files.

I propose a change that allows for `gc` to generate the SHA1SUm of cache files, and verifies that the hash matches the cache file name (Which the file is the SHA1SUm when it's uploaded). If it does not match it will be removed.

### -Other Notes-
 
I thought I would follow camping rules and try to leave things a bit better then when I got there. So I've done the following.
- Refactored `Gc` to make it more readable and now fully tested.
- Created a utility function for verifying a file's SHA1Sum, also fully tested.
- Introduced `goconvey`, a BDD style testing framework

